### PR TITLE
🔖 Release 0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turplanlegger-webui",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "dependencies": {
     "@azure/msal-browser": "^2.38.3",


### PR DESCRIPTION
Update dependencies and CI:
* ⬆ Dependency: Bump react-i18next from 13.3.1 to 14.1.3 (#263)
* ⬆ Dependency: Bump i18next from 23.6.0 to 23.12.1 (#262)
* ⬆ Dependency: Bump @testing-library/jest-dom (#259)
* ⬆ Dependency: Bump react-router-dom from 6.18.0 to 6.24.1 (#258)
* 👷 CI: Bump docker/build-push-action from 5 to 6 (#256)
* ⬆ Dependency: Bump @mui/x-date-pickers from 6.18.0 to 7.10.0 (#257